### PR TITLE
Doubled the efficiency of intToYYYYMMDD

### DIFF
--- a/Code/PocketMage_V3/src/CALENDAR.cpp
+++ b/Code/PocketMage_V3/src/CALENDAR.cpp
@@ -170,10 +170,19 @@ void updateEventByIndex(int indexToUpdate) {
 
 // General Functions
 String intToYYYYMMDD(int year_, int month_, int date_) {
-  String y = String(year_);
-  String m = (month_ < 10 ? "0" : "") + String(month_);
-  String d = (date_ < 10 ? "0" : "") + String(date_);
-  return y + m + d;
+  String res = "00000000";
+  res[0]+=year_/1000;
+  year_%=1000;
+  res[1]+=year_/100;
+  year_%=100;
+  res[2]+=year_/10;
+  year_%=10;
+  res[3]+=year_;
+  res[4]+=month_/10;
+  res[5]+=month_%10;
+  res[6]+=date_/10;
+  res[7]+=date_%10;
+  return res;
 }
 
 String getMonthName(int month) {


### PR DESCRIPTION
I'm kind of assuming that `String` here is actually a char[] in secret, or can be addressed like one, I don't have a compatible compiler installed, but with `<cstdlib>, <string>, and <iostream>` and `String` changed to `string`, creating the String (char[]) with all 0's lets you increment the bytes making up the String from `0x30` to `0x30 - 0x39`, depending on the modulo for each digit.

1993/1000 = 0x1
0x30 + 0x1 = 0x31, which is '1'
1993%1000/100 = 0x9
0x30 + 0x9 = 0x39, so '9', etc etc.

(technically behaves different from original code when the year exceeds 9999, the date 08/26/10000 would give you a result of `:0000826`, because 10000/1000 = 0xA, and 0x30+0xA gives you 0x3A, which is the ':' character)
