### PR TITLE
Jingle refactor

### DIFF
--- a/Code/PocketMage_V3/.clang-format
+++ b/Code/PocketMage_V3/.clang-format
@@ -1,0 +1,89 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: false
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterStruct: false
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+ColumnLimit: 100
+CommentPragmas: '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+ForEachMacros: []
+IncludeCategories:
+  - Regex: '^<.*\.h>'
+    Priority: 1
+  - Regex: '^<.*'
+    Priority: 2
+  - Regex: '.*'
+    Priority: 3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentWidth: 2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd: ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments: true
+SortIncludes: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Cpp11
+TabWidth: 2
+UseTab: Never
+

--- a/Code/PocketMage_V3/lib/pocketmage_buzzer/include/pocketmage_bz.h
+++ b/Code/PocketMage_V3/lib/pocketmage_buzzer/include/pocketmage_bz.h
@@ -9,19 +9,43 @@
 #include <Arduino.h>
 #include <Buzzer.h>
 
-enum class Jingle : uint8_t { Startup, Shutdown };
+enum class Jingle_ : uint8_t { Startup, Shutdown };
+
+struct Note {
+  int key;
+  int duration;
+};
+
+struct Jingle {
+  const Note* notes;  // const because we don't want to modify the tune
+  size_t len;
+};
+
+namespace Jingles {
+constexpr static const Note startupNotes[] = {
+    {NOTE_A8, 120}, {NOTE_B8, 120}, {NOTE_C8, 120}, {NOTE_D8, 120}};
+
+constexpr static const Note shutdownNotes[] = {
+    {NOTE_D8, 120}, {NOTE_C8, 120}, {NOTE_B8, 120}, {NOTE_A8, 120}};
+
+const Jingle Startup = {startupNotes, sizeof(startupNotes) / sizeof(startupNotes[0])};
+const Jingle Shutdown = {shutdownNotes, sizeof(shutdownNotes) / sizeof(shutdownNotes[0])};
+
+};  // namespace jingle
 
 // ===================== BZ CLASS =====================
 class PocketmageBZ {
-public:
-  explicit PocketmageBZ(Buzzer &bz) : buzzer_(bz) {}
+ public:
+  explicit PocketmageBZ(Buzzer& bz) : buzzer_(bz) {}
 
   // Main methods
   void wireBZ(Buzzer* hw);
-  void playJingle(Jingle jingle);
+  // void playJingle(Jingle_ jingle);
 
-private:
-    Buzzer      &buzzer_;
+  void playJingle(const Jingle& jingle) const;
+
+ private:
+  Buzzer& buzzer_;
 };
 
 void wireBZ();

--- a/Code/PocketMage_V3/lib/pocketmage_buzzer/include/pocketmage_bz.h
+++ b/Code/PocketMage_V3/lib/pocketmage_buzzer/include/pocketmage_bz.h
@@ -9,6 +9,17 @@
 #include <Arduino.h>
 #include <Buzzer.h>
 
+/* ADDING NEW JINGLES
+
+
+   constexpr static const Note Jingles::myMelodyNotes[] = {
+      {NOTE_A8, 120}, {NOTE_B8, 120}, {NOTE_C8, 120}, {NOTE_D8, 120}
+   }; // This is constexpr so its compile time, not run time
+   const Jingles::myMelody = { myMelodyNotes, sizeof(myMelodyNotes) / sizeof(myMelodyNotes[0]);
+
+ 
+ * */
+
 struct Note {
   int key;
   int duration;

--- a/Code/PocketMage_V3/lib/pocketmage_buzzer/include/pocketmage_bz.h
+++ b/Code/PocketMage_V3/lib/pocketmage_buzzer/include/pocketmage_bz.h
@@ -9,8 +9,6 @@
 #include <Arduino.h>
 #include <Buzzer.h>
 
-enum class Jingle_ : uint8_t { Startup, Shutdown };
-
 struct Note {
   int key;
   int duration;

--- a/Code/PocketMage_V3/lib/pocketmage_buzzer/src/pocketmage_bz.cpp
+++ b/Code/PocketMage_V3/lib/pocketmage_buzzer/src/pocketmage_bz.cpp
@@ -8,26 +8,6 @@
 #include <pocketmage_bz.h>
 
 // ===================== main functions =====================
-/* void PocketmageBZ::playJingle(Jingle_ j) {
-  buzzer_.begin(0);
-  switch (j) {
-    case Jingle_::Startup:
-      buzzer_.sound(NOTE_A8,120);
-      buzzer_.sound(NOTE_B8,120);
-      buzzer_.sound(NOTE_C8,120);
-      buzzer_.sound(NOTE_D8,120);
-      break;
-    case Jingle_::Shutdown:
-      buzzer_.sound(NOTE_D8,120);
-      buzzer_.sound(NOTE_C8,120);
-      buzzer_.sound(NOTE_B8,120);
-      buzzer_.sound(NOTE_A8,120);
-      break;
-  }
-  buzzer_.sound(0,80);
-  buzzer_.end(0);
-} */
-
 void PocketmageBZ::playJingle(const Jingle& jingle) const {
   if (jingle.notes == nullptr || jingle.len == 0) {
     return;  // No valid notes to play

--- a/Code/PocketMage_V3/lib/pocketmage_buzzer/src/pocketmage_bz.cpp
+++ b/Code/PocketMage_V3/lib/pocketmage_buzzer/src/pocketmage_bz.cpp
@@ -8,16 +8,16 @@
 #include <pocketmage_bz.h>
 
 // ===================== main functions =====================
-void PocketmageBZ::playJingle(Jingle j) {
+/* void PocketmageBZ::playJingle(Jingle_ j) {
   buzzer_.begin(0);
   switch (j) {
-    case Jingle::Startup:
+    case Jingle_::Startup:
       buzzer_.sound(NOTE_A8,120);
       buzzer_.sound(NOTE_B8,120);
       buzzer_.sound(NOTE_C8,120);
       buzzer_.sound(NOTE_D8,120);
       break;
-    case Jingle::Shutdown:
+    case Jingle_::Shutdown:
       buzzer_.sound(NOTE_D8,120);
       buzzer_.sound(NOTE_C8,120);
       buzzer_.sound(NOTE_B8,120);
@@ -26,4 +26,19 @@ void PocketmageBZ::playJingle(Jingle j) {
   }
   buzzer_.sound(0,80);
   buzzer_.end(0);
+} */
+
+void PocketmageBZ::playJingle(const Jingle& jingle) const {
+  if (jingle.notes == nullptr || jingle.len == 0) {
+    return;  // No valid notes to play
+  }
+
+  buzzer_.begin(0);  // Initialize buzzer
+
+  for (size_t i = 0; i < jingle.len; ++i) {
+    buzzer_.sound(jingle.notes[i].key, jingle.notes[i].duration);
+  }
+
+  buzzer_.sound(0, 80);  // End the sound
+  buzzer_.end(0);        // Stop the buzzer
 }

--- a/Code/PocketMage_V3/src/USB.cpp
+++ b/Code/PocketMage_V3/src/USB.cpp
@@ -50,7 +50,7 @@ void USBAppShutdown() {
       OLED().oledWord("Insert SD Card and Reboot!");
       delay(5000);
       u8g2.setPowerSave(1);
-      BZ().playJingle(Jingle::Shutdown);
+      BZ().playJingle(Jingles::Shutdown);
       esp_deep_sleep_start();
       return;
     }

--- a/Code/PocketMage_V3/src/setup/buzzerSetup.cpp
+++ b/Code/PocketMage_V3/src/setup/buzzerSetup.cpp
@@ -6,7 +6,7 @@ static PocketmageBZ bz(buzzer);
 
 // Setup for Buzzer Class
 void setupBZ() {
-  BZ().playJingle(Jingle::Startup);
+  BZ().playJingle(Jingles::Startup);
 }
 
 

--- a/Code/PocketMage_V3/src/setup/sdSetup.cpp
+++ b/Code/PocketMage_V3/src/setup/sdSetup.cpp
@@ -26,7 +26,7 @@ void setupSD() {
       // Put OLED to sleep
       u8g2.setPowerSave(1);
       // Shut Down Jingle
-      BZ().playJingle(Jingle::Shutdown);
+      BZ().playJingle(Jingles::Shutdown);
       // Sleep
       esp_deep_sleep_start();
       return;

--- a/Code/PocketMage_V3/src/sysFunc.cpp
+++ b/Code/PocketMage_V3/src/sysFunc.cpp
@@ -741,7 +741,7 @@ void checkTimeout() {
         display.hibernate();
         
         //Sleep the device
-        BZ().playJingle(Jingle::Shutdown);
+        BZ().playJingle(Jingles::Shutdown);
         esp_deep_sleep_start();
       }
   }
@@ -776,7 +776,7 @@ void checkTimeout() {
       newState = true;
       
       // Shutdown Jingle
-      BZ().playJingle(Jingle::Shutdown);
+      BZ().playJingle(Jingles::Shutdown);
 
       // Clear screen
       display.setFullWindow();
@@ -833,7 +833,7 @@ void checkTimeout() {
     EINK().forceSlowFullUpdate(true);
 
     // Play startup jingle
-    BZ().playJingle(Jingle::Startup);
+    BZ().playJingle(Jingles::Startup);
 
     EINK().refresh();
     delay(200);
@@ -852,7 +852,7 @@ void deepSleep(bool alternateScreenSaver) {
   }
   
   // Shutdown Jingle
-  BZ().playJingle(Jingle::Shutdown);
+  BZ().playJingle(Jingles::Shutdown);
 
   if (alternateScreenSaver == false) {
     int numScreensavers = sizeof(ScreenSaver_allArray) / sizeof(ScreenSaver_allArray[0]);


### PR DESCRIPTION
> [!Caution]
> This code compiles, however it has not been tested on hardware

This PR aims to make the code for Jingles more maintainable:
- Moved from a large switch statement to a data driven approach with an array of `Note`s 
- Each note contains the base tone (C1, D3, etc) and the duration
- Moved Jingle related stuff into it's own namespace to avoid pollution
- To add new Jingles:
```cpp
constexpr static const Note Jingles::myMelodyNotes[] = {
    {NOTE_A8, 120}, {NOTE_B8, 120}, {NOTE_C8, 120}, {NOTE_D8, 120}
}; // This is constexpr so its compile time, not run time

const Jingles::myMelody = { myMelodyNotes, sizeof(myMelodyNotes) / sizeof(myMelodyNotes[0]);
```

- The `playJingle` function now iterates over any given jingle and plays it 
  `void playJingle(const Jingle& jingle) const;`
- Updated all calls of `playJingle`